### PR TITLE
Remove aspnet-contrib NuGet feed

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="aspnet-contrib" value="https://www.myget.org/F/aspnet-contrib/api/v3/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Remove need to use the aspnet-contrib MyGet feed as the Apple package is now in NuGet.org.
