### PR TITLE
Revert "Bump Microsoft.IdentityModel.Protocols.OpenIdConnect from 6.17.0 to 6.19.0"

### DIFF
--- a/src/SignInWithApple/SignInWithApple.csproj
+++ b/src/SignInWithApple/SignInWithApple.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.2.2" />
     <PackageReference Include="Azure.Identity" Version="1.6.0" />
     <PackageReference Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="6.0.5" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.19.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.17.0" />
   </ItemGroup>
   <Target Name="AddGeneratedContentItems" BeforeTargets="AssignTargetPaths">
     <ItemGroup>


### PR DESCRIPTION
Reverts martincostello/SignInWithAppleSample#172 due to issue with `cty` claim.