### PR TITLE
Fix obsolete warnings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,6 +8,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/martincostello/SignInWithAppleSample.git</RepositoryUrl>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <UseArtifactsOutput>true</UseArtifactsOutput>
   </PropertyGroup>
 </Project>

--- a/tests/SignInWithApple.Tests/AppleClientSecretGeneratorTests.cs
+++ b/tests/SignInWithApple.Tests/AppleClientSecretGeneratorTests.cs
@@ -74,17 +74,16 @@ public class AppleClientSecretGeneratorTests
             securityToken.Payload.ShouldContainKeyAndValue("aud", "https://appleid.apple.com");
             securityToken.Payload.ShouldContainKeyAndValue("iss", "my-team-id");
             securityToken.Payload.ShouldContainKeyAndValue("sub", "my-client-id");
-            securityToken.Payload.Iat.HasValue.ShouldBeTrue();
-            securityToken.Payload.Exp.HasValue.ShouldBeTrue();
+            securityToken.Payload.Expiration.HasValue.ShouldBeTrue();
 
             securityToken.Payload.Keys.Order().ShouldBe(
                 new string[] { "aud", "exp", "iat", "iss", "nbf", "sub" },
                 Case.Sensitive,
                 "JWT payload contains unexpected additional claims.");
 
-            ((long)securityToken.Payload.Iat!.Value).ShouldBeGreaterThanOrEqualTo(utcNow.ToUnixTimeSeconds());
-            ((long)securityToken.Payload.Exp!.Value).ShouldBeGreaterThanOrEqualTo(utcNow.AddSeconds(60).ToUnixTimeSeconds());
-            ((long)securityToken.Payload.Exp.Value).ShouldBeLessThanOrEqualTo(utcNow.AddSeconds(70).ToUnixTimeSeconds());
+            securityToken.Payload.IssuedAt.ShouldBeGreaterThanOrEqualTo(utcNow.UtcDateTime.AddSeconds(-1 * (utcNow.Second + utcNow.Millisecond)));
+            securityToken.Payload.Expiration!.Value.ShouldBeGreaterThanOrEqualTo(utcNow.AddSeconds(60).ToUnixTimeSeconds());
+            securityToken.Payload.Expiration.Value.ShouldBeLessThanOrEqualTo(utcNow.AddSeconds(70).ToUnixTimeSeconds());
         });
     }
 


### PR DESCRIPTION
- Fix obsolete warnings for IdentityModel 7.0.0.
- Enable warnings as errors to catch future warnings in pull requests before merging.
