### PR TITLE
Use SHA-256 for checksums

### DIFF
--- a/src/SignInWithApple/SignInWithApple.csproj
+++ b/src/SignInWithApple/SignInWithApple.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <AspNetCoreHostingModel>inprocess</AspNetCoreHostingModel>
     <AssemblyName>MartinCostello.SignInWithApple</AssemblyName>
+    <ChecksumAlgorithm>SHA256</ChecksumAlgorithm>
     <NeutralLanguage>en-US</NeutralLanguage>
     <OutputType>Exe</OutputType>
     <PreserveCompilationContext>true</PreserveCompilationContext>


### PR DESCRIPTION
Fix `BA2004` warning from Binskim.
