### PR TITLE
Fix ASPDEPR004 warning

### DIFF
--- a/tests/SignInWithApple.Tests/AppleClientSecretGeneratorTests.cs
+++ b/tests/SignInWithApple.Tests/AppleClientSecretGeneratorTests.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Shouldly;
@@ -87,14 +88,16 @@ public class AppleClientSecretGeneratorTests(ITestOutputHelper outputHelper)
         Func<AppleGenerateClientSecretContext, Task> actAndAssert)
     {
         // Arrange
-        var builder = new WebHostBuilder()
-            .ConfigureLogging((p) => p.AddXUnit(outputHelper).SetMinimumLevel(LogLevel.Debug))
-            .Configure((app) => app.UseAuthentication())
-            .ConfigureServices((services) =>
-            {
-                services.AddAuthentication()
-                        .AddApple();
-            });
+        var builder = new HostBuilder()
+            .ConfigureWebHost(
+                (builder) =>
+                    builder.ConfigureLogging((p) => p.AddXUnit(outputHelper).SetMinimumLevel(LogLevel.Debug))
+                           .Configure((app) => app.UseAuthentication())
+                           .ConfigureServices((services) =>
+                           {
+                               services.AddAuthentication()
+                                       .AddApple();
+                           }));
 
         using var host = builder.Build();
 


### PR DESCRIPTION
Resolve obsolete warning about `WebHostBuilder` to prepare for .NET 10.
