### PR TITLE
Refactor use of secrets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,10 @@ jobs:
     env:
       PUBLISH_CONTAINER: ${{ github.event.repository.fork == false && github.ref_name == github.event.repository.default_branch && matrix.os-name == 'linux' && vars.CONTAINER_REGISTRY != '' }}
 
+    environment:
+      name: build
+      deployment: false
+
     outputs:
       container-tag: ${{ steps.publish-container.outputs.container-tag }}
 
@@ -80,13 +84,18 @@ jobs:
       shell: pwsh
       run: ./build.ps1
 
-    - name: Docker log in
-      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+    - name: Azure log in
+      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
       if: env.PUBLISH_CONTAINER == 'true'
       with:
-        registry: ${{ vars.CONTAINER_REGISTRY }}
-        username: ${{ secrets.ACR_REGISTRY_USERNAME }}
-        password: ${{ secrets.ACR_REGISTRY_PASSWORD }}
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+    - name: Log in to Azure Container Registry
+      shell: pwsh
+      if: env.PUBLISH_CONTAINER == 'true'
+      run: az acr login --name ${env:GITHUB_REPOSITORY_OWNER}
 
     - name: Publish container
       id: publish-container

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -20,8 +20,14 @@ jobs:
       group: ${{ github.workflow }}
       cancel-in-progress: false
 
+    environment:
+      name: container-scan
+      deployment: false
+
     permissions:
+      actions: write
       contents: read
+      id-token: write
       security-events: write
 
     steps:
@@ -32,6 +38,17 @@ jobs:
           filter: 'tree:0'
           persist-credentials: false
           show-progress: false
+
+      - name: Azure log in
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Log in to Azure Container Registry
+        shell: pwsh
+        run: az acr login --name ${env:GITHUB_REPOSITORY_OWNER}
 
       - name: Configure Trivy
         id: configure
@@ -45,8 +62,6 @@ jobs:
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
-          TRIVY_USERNAME: ${{ secrets.TRIVY_USERNAME }}
-          TRIVY_PASSWORD: ${{ secrets.TRIVY_PASSWORD }}
         with:
           image-ref: ${{ steps.configure.outputs.container-image }}
           format: 'sarif'
@@ -65,8 +80,6 @@ jobs:
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
-          TRIVY_USERNAME: ${{ secrets.TRIVY_USERNAME }}
-          TRIVY_PASSWORD: ${{ secrets.TRIVY_PASSWORD }}
         with:
           image-ref: ${{ steps.configure.outputs.container-image }}
           format: 'json'
@@ -131,5 +144,5 @@ jobs:
           github.event_name == 'schedule' &&
           steps.check-for-vulnerabilities.outputs.has-vulnerabilities == 'true'
         env:
-          GH_TOKEN: ${{ secrets.COSTELLOBOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh workflow run build.yml

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -5,7 +5,5 @@ rules:
     disable: true
   dependabot-cooldown:
     disable: true
-  secrets-outside-env:
-    disable: true
   undocumented-permissions:
     disable: true


### PR DESCRIPTION
- Use OIDC to authenticate with Azure.
- Scope all secrets to environments.
- Use GITHUB_TOKEN to dispatch workflow.
- Enable `secrets-outside-env` zizmor rule.
